### PR TITLE
simplify wording

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -564,10 +564,8 @@ The primary data in the response document **MUST** be one of the following:
 * an object containing `type` and `id` members for non-empty to-one
   relationships.
 * an empty array (`[]`) for empty to-many relationships
-* an object containing `type` and `ids` members for non-empty homogenous
-  to-many relationships.
-* an array of objects each containing `type` and `id` members for non-empty
-  heterogenous to-many relationships.
+* an object containing `type` and `ids` members for non-empty to-many
+  relationships (homogeneous or heterogeneous).
 
 The top-level *links object* **MAY** contain `self` and `resource` links,
 as described for link objects.


### PR DESCRIPTION
The last two points seem kind of redundant. This commit combines
them while retaining the presumed intent, which is to hammer home
the point that `id` and `type` are required for both homogeneous
and heterogeneous collections.
